### PR TITLE
fix deprecate prettier option

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
   "endOfLine": "auto",
   "htmlWhitespaceSensitivity": "css",
   "insertPragma": false,
-  "jsxBracketSameLine": false,
+  "BracketSameLine": false,
   "jsxSingleQuote": false,
   "printWidth": 80,
   "proseWrap": "preserve",


### PR DESCRIPTION
jsxBracketSameLine  -> BracketSameLine

https://prettier.io/blog/2021/09/09/2.4.0.html#:~:text=This%20release%20renames%20the%20jsxBracketSameLine,such%20as%20class%20static%20blocks.